### PR TITLE
Add the error message when the weaving method fails

### DIFF
--- a/src/InlineMethod.Fody/ModuleWeaver.cs
+++ b/src/InlineMethod.Fody/ModuleWeaver.cs
@@ -31,7 +31,7 @@ public class ModuleWeaver : BaseModuleWeaver
                 }
                 catch (Exception)
                 {
-                    WriteMessage("Error occured when weaving call instruction: \n" +
+                    WriteMessage("Error occured when process call instruction: \n" +
                         $"\tCaller: {method.FullName} (IL offset: 0x{instruction.Offset:X8})\n" +
                         $"\tCallee: {calledMethod.FullName}", MessageImportance.High);
                     throw;

--- a/src/InlineMethod.Fody/ModuleWeaver.cs
+++ b/src/InlineMethod.Fody/ModuleWeaver.cs
@@ -1,6 +1,9 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
 using System.Linq;
+
 using Fody;
+
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 
@@ -22,7 +25,17 @@ public class ModuleWeaver : BaseModuleWeaver
             {
                 ProcessMethod(calledMethodDefinition);
                 var inlineMethodWeaver = new InlineMethodWeaver(this, instruction, method, calledMethodDefinition);
-                inlineMethodWeaver.Process();
+                try
+                {
+                    inlineMethodWeaver.Process();
+                }
+                catch (Exception)
+                {
+                    WriteMessage("Error occured when weaving call instruction: \n" +
+                        $"\tCaller: {method.FullName} (IL offset: 0x{instruction.Offset:X8})\n" +
+                        $"\tCallee: {calledMethod.FullName}", MessageImportance.High);
+                    throw;
+                }
             }
         }
     }


### PR DESCRIPTION
As the title says, I make a simple message that will show when the InlineMethodWeaver.Process() fails.

When the weaver failed，it would show:
```
Error occured when process call instruction:
　Caller: [the method that is inlining] (IL offset: [a hexadecimal offset])
　Callee: [the method that is inlined into the caller]
[Normal Fody error stacktrace]
```